### PR TITLE
Fixing URL for saved crafting list

### DIFF
--- a/app/views/pages/list.blade.php
+++ b/app/views/pages/list.blade.php
@@ -83,7 +83,7 @@
 				<h4 class="modal-title">Copy this link</h4>
 			</div>
 			<div class="modal-body">
-				<textarea class='form-control'>http://craftingasaservice.com/list/saved/{{ $saved_link }}</textarea>
+				<textarea class='form-control'>http://ffxivcrafting.com/list/saved/{{ $saved_link }}</textarea>
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
This has been a minor annoyance since the URL change, where the crafting list saved links would generate now-broken URLs pointing to the old domain.